### PR TITLE
Updated Fix for #2 - Command palette hang while searching for Vagrantfile

### DIFF
--- a/Vagrant.py
+++ b/Vagrant.py
@@ -264,32 +264,6 @@ class VagrantDestroyUp(Vagrant):
             self.run_command('up', self.getVagrantConfigPath())
 
 class VagrantInit(Vagrant):
-    def getVagrantConfigPath(self):
-        window = sublime.active_window();
-        
-        folder = window.folders()[0]
-
-        found = False
-
-        while not found:
-            self.output_view.append_line(folder)
-
-            if exists(folder + "/Vagrantfile"):
-                self.output_view.append_error('This project already has a Vagrant config file.')
-                raise Exception("This project already has a Vagrant config file.")
-
-            # If this directory has the git folder, stop.
-            if exists(folder + "/.git") and isdir(folder + "/.git"):
-                return folder
-
-            # Have we hit rock bottom?
-            if dirname(folder) == folder:
-                self.output_view.append_error('Unable to find root folder, sublime-vagrant only supports git right now.')
-                raise Exception("Unable to find root folder, sublime-vagrant only supports git right now.")
-
-            # Try the next directory up.
-            folder = dirname(folder)
-
     def execute(self, path=''):
         self.run_command('init', self.getVagrantConfigPath())
 
@@ -305,36 +279,13 @@ class VagrantProvision(Vagrant):
     def execute(self, path=''):
         self.run_command('provision', self.getVagrantConfigPath())
 
-class VagrantBaseCommand(sublime_plugin.ApplicationCommand):
+class VagrantBaseCommand(sublime_plugin.WindowCommand):
     def run(self, paths=[]):
         print "Not implemented"
 
-    def getVagrantConfigPath(self):
-        window = sublime.active_window();
-        
-        folder = window.folders()[0]
-
-        found = False
-
-        while not found:
-            if exists(folder + "/Vagrantfile"):
-                return folder
-
-            # If this directory has the git folder, stop.
-            if exists(folder + "/.git") and isdir(folder + "/.git"):
-                raise Exception("Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.")
-
-            # Have we hit rock bottom?
-            if dirname(folder) == folder:
-                self.output_view.append_error('Unable to find root folder, sublime-vagrant only supports git right now.')
-                raise Exception("Unable to find root folder, sublime-vagrant only supports git right now.")
-
-            # Try the next directory up.
-            folder = dirname(folder)
-
     def is_enabled(self):
         try:
-            self.getVagrantConfigPath()
+            Vagrant().getVagrantConfigPath()
         except Exception:
             return False
 


### PR DESCRIPTION
Taking direction from most recent suggestions, this consolidates the Vagrantfile search to just the Vagrant class.  I've tested this on a couple projects, vagrant and non-vagrant, and it seems to be working.

That said, the way I called out to getVagrantConfigPath from VagrantBaseCommand feels like it's wrong to me.  Though, not being a "real" python programmer, I don't know if or how wrong it may be.
