### PR TITLE
[Fixed] Unexpected messages in console

### DIFF
--- a/Vagrant.py
+++ b/Vagrant.py
@@ -56,9 +56,9 @@ class PrefsMeta(type):
                     return self.validVagrantfilePath
 
                 # If this directory has the git folder, stop.
-                if exists(folder + "/.git") and isdir(folder + "/.git"):
-                    print('Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.')
-                    raise Exception("Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.")
+                # if exists(folder + "/.git") and isdir(folder + "/.git"):
+                    # print('Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.')
+                    # raise Exception("Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.")
 
                 # Have we hit rock bottom?
                 if dirname(folder) == folder:


### PR DESCRIPTION
### 1. Settings

For example, I have `project1` and `project2`. In `project1` I don't have `Vagrantfile` in top folder of my sidebar, in `project2` I have `Vagrantfile` in top folder of my sidebar.

### 2. Behavior before pull request

If I work in `project1`, I get in Sublime Text console each a couple of minutes:

    Searching : D:\CriticMarkup
    Unable to find Vagrantfile, found .git folder and assumed this is the root of your project.

### 3. Behavior after pull request

I don't get this unexpected messages in console.

Thanks.